### PR TITLE
some improvements during usage in a project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>msal4j</artifactId>
-            <version>1.8.1</version>
+            <version>1.9.1</version>
         </dependency>
 
         <dependency>
@@ -111,4 +111,3 @@
     </build>
 
 </project>
-

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>msal4j</artifactId>
-            <version>1.7.0</version>
+            <version>1.8.1</version>
         </dependency>
 
         <dependency>

--- a/src/main/resources/authentication.properties
+++ b/src/main/resources/authentication.properties
@@ -18,3 +18,5 @@ app.redirectUri=http://localhost:8080/ms-identity-b2c-java-servlet-webapp-authen
 #  in seconds:
 app.stateTTL=600
 app.homePage=http://localhost:8080/ms-identity-b2c-java-servlet-webapp-authentication/index
+# values for prompt, might be login, select_account, consent, admin_consent or empty (none), see https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-js-prompt-behavior
+app.prompt=select_account

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -18,6 +18,12 @@
 <body>
 
 <%@ include file="navbar.jsp" %>
+<%
+    // enable call / (no need to call /index )
+    if (request.getAttribute("bodyContent") == null){
+        request.setAttribute("bodyContent", "auth/status.jsp");
+    }
+%>
 
 <div class="container body-content">
         <jsp:include page="${bodyContent}" ></jsp:include>


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* pom.xml use msal4j > 1.8.0 because IAccount is serializable then, see https://github.com/AzureAD/microsoft-authentication-library-for-java/blob/dev/changelog.txt and https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/292

* AuthHelper.java and authentication.properties: add a configuration property app.prompt: the value might be login, select_account (was/is the default), consent, admin_consent or not set/empty (none), see https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-js-prompt-behavior

* AuthHelper.java: remove one unnecessary variable initialization (line 35/36) and check (line 228/238) causing a warning

* AuthHelper.java: improve exception, if state is null or doesn't match or TTL expired
(this will happen, if different session e.g. caused by different domains used as URL (used in the browser), app.redirectUri and app.homePage do not match!)

* index.jsp: enable call / (e.g. http://localhost:8080/ms-identity-b2c-java-servlet-webapp-authentication/ - no need to call /index )


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x] Bugfix
[ x] Feature
[ x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

* Test the code
Change app.prompt to empty ("") and compile a new causing the authorize-call to set no prompt-parameter.
Change app.prompt to login and compile a new causing the authorize-call to use prompt=login.

## What to Check
Verify that the following are valid
* http://localhost:8080/ms-identity-b2c-java-servlet-webapp-authentication/ can now be called
* no errors about serialization is written into localhost.YYYY-MM-DD.log if the war is used in tomcat
* the configured app.prompt is used
